### PR TITLE
0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.3.0
+
+### Added
+* **Global Dismiss All Functionality**: New static `dismissAll()` method in `AnchorToastController` for dismissing all active toasts
+  - `AnchorToastController.dismissAll()` dismisses toasts from all controllers across the entire application
+  - Automatic controller registry system tracks all active controllers
+  - Controllers are automatically registered on creation and unregistered on disposal
+  - Safe concurrent modification handling prevents issues when dismissing multiple toasts
+
+### Improved  
+* **Example App Enhancement**: Updated example to demonstrate the new `dismissAll()` functionality
+  - Simplified "Dismiss All Toasts" button implementation using the new static method
+  - Cleaner code by removing the need to manually call dismiss on each individual controller
+
 ## 0.2.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A Flutter package for displaying contextual toasts anchored to widgets with smar
 - 🎯 **Smart Positioning**: Automatically determines whether to show toasts above or below the anchor widget based on available space
 - 🎨 **Smooth Animations**: Beautiful scale and opacity animations for toast appearance and disappearance
 - ⏰ **Auto-dismiss**: Toasts automatically disappear after a specified duration
-- 🎮 **Manual Control**: Dismiss toasts manually using the controller
+- 🎮 **Manual Control**: Dismiss toasts manually using the controller or dismiss all toasts globally
 - 🧩 **Simple API**: Easy-to-use widget wrapper with controller
 - 📱 **Overlay Support**: Uses Flutter's Overlay system for proper z-index handling
 
@@ -76,6 +76,7 @@ The main controller class for managing toast displays.
 
 - `showToast({required Widget toast, required Duration duration, double offset = 8.0, bool enableHapticFeedback = true, bool? showAbove})` - Shows a toast anchored to the registered context
 - `dismiss()` - Manually dismisses the currently shown toast
+- `static dismissAll()` - Dismisses all currently active toasts from all controllers across the entire application
 - `dispose()` - Disposes the controller and cleans up resources
 
 #### Parameters
@@ -183,6 +184,62 @@ controller.showToast(
   duration: Duration(seconds: 2),
   offset: 16.0, // Larger offset for more spacing
 );
+```
+
+### Dismissing Toasts
+
+You can dismiss toasts individually or all at once:
+
+```dart
+// Dismiss a specific toast using its controller
+controller.dismiss();
+
+// Dismiss all active toasts across the entire application
+AnchorToastController.dismissAll();
+
+// Example: Dismiss all toasts when navigating away from a screen
+class MyWidget extends StatefulWidget {
+  @override
+  _MyWidgetState createState() => _MyWidgetState();
+}
+
+class _MyWidgetState extends State<MyWidget> {
+  final _controller = AnchorToastController();
+
+  @override
+  void dispose() {
+    // Clean up individual controller
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _dismissAllToasts() {
+    // This will dismiss toasts from all controllers in the app
+    AnchorToastController.dismissAll();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        AnchorToast(
+          controller: _controller,
+          child: ElevatedButton(
+            onPressed: () => _controller.showToast(
+              toast: Container(/* your toast widget */),
+              duration: Duration(seconds: 3),
+            ),
+            child: Text('Show Toast'),
+          ),
+        ),
+        ElevatedButton(
+          onPressed: _dismissAllToasts,
+          child: Text('Dismiss All Toasts'),
+        ),
+      ],
+    );
+  }
+}
 ```
 
 ## Smart Positioning

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -268,13 +268,7 @@ class _HomePageState extends State<HomePage> {
                     foregroundColor: Colors.white,
                   ),
                   onPressed: () {
-                    _infoController.dismiss();
-                    _warningController.dismiss();
-                    _errorController.dismiss();
-                    _rapidFireController.dismiss();
-                    _longController.dismiss();
-                    _customController.dismiss();
-                    _bottomController.dismiss();
+                    AnchorToastController.dismissAll();
                   },
                   child: const Text('Dismiss All Toasts'),
                 ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: anchor_toast
 description: "A Flutter package for displaying contextual toasts anchored to widgets with smart positioning and smooth animations."
-version: 0.2.0
+version: 0.3.0
 homepage: https://github.com/rasitayaz/flutter-anchor-toast
 
 environment:


### PR DESCRIPTION
### Added
* **Global Dismiss All Functionality**: New static `dismissAll()` method in `AnchorToastController` for dismissing all active toasts
  - `AnchorToastController.dismissAll()` dismisses toasts from all controllers across the entire application
  - Automatic controller registry system tracks all active controllers
  - Controllers are automatically registered on creation and unregistered on disposal
  - Safe concurrent modification handling prevents issues when dismissing multiple toasts

### Improved  
* **Example App Enhancement**: Updated example to demonstrate the new `dismissAll()` functionality
  - Simplified "Dismiss All Toasts" button implementation using the new static method
  - Cleaner code by removing the need to manually call dismiss on each individual controller